### PR TITLE
issue_5: add max encoder to KBinsDiscretizer

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -306,12 +306,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         np.clip(Xt, 0, self.n_bins_ - 1, out=Xt)
 
         if self.encode == 'max':
-            encoder = lambda x: np.max(x)
-            return self._aggregate_encoder_helper(X, Xt, encoder)
+            return self._aggregate_encoder_helper(X, Xt, lambda x: np.max(x))
 
         if self.encode == 'mode':
-            encoder =  lambda x: stats.mode(x)[0][0]
-            return self._aggregate_encoder_helper(X, Xt, encoder)
+            return self._aggregate_encoder_helper(X, Xt, lambda x: stats.mode(x)[0][0])
 
         if self.encode == 'mean':
             return self._aggregate_encoder_helper(X, Xt, lambda x: mean(x, axis=0))

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -286,6 +286,29 @@ def test_transform_median():
 
     # ensure that original array is not mutated
     assert not np.array_equal(X, Xt)
+def test_transform_max():
+    expected_2bins = [[-1,   2.5, -3,  -0.5],
+                      [-1,   2.5, -3,  -0.5],
+                      [ 1,   4.5, -1,   2],
+                      [ 1,   4.5, -1,   2]]
+
+    expected_3bins = [[-2,   1.5, -4,  -1],
+                      [-1,   2.5, -3,  -0.5],
+                      [ 1,   4.5, -1,   2],
+                      [ 1,   4.5, -1,   2]]
+
+    # with 2 bins
+    est = KBinsDiscretizer(n_bins=2, encode='max')
+    Xt = est.fit_transform(X)
+    assert_array_equal(expected_2bins, Xt)
+
+    # with 3 bins
+    est = KBinsDiscretizer(n_bins=3, encode='max')
+    Xt = est.fit_transform(X)
+    assert_array_equal(expected_3bins, Xt)
+
+    # check that original array is not mutated
+    assert not np.array_equal(X, Xt)
 
 @pytest.mark.parametrize(
     'strategy, expected_inv',


### PR DESCRIPTION
#### Reference Issues/PRs
issue reference: https://github.com/VishwaP98/lets-git-it-scikit-learn/issues/5
parent PR: https://github.com/VishwaP98/lets-git-it-scikit-learn/pull/1
#### What does this implement/fix? Explain your changes.
find the max value in each bin after KBinsDiscretizer allocates each entry to a specific bin.
