### PR TITLE
Add Median encoder for KbinsDiscretizer

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -10,7 +10,7 @@ import numbers
 import numpy as np
 import warnings
 import copy
-from scipy import stats
+from scipy import stats, mean
 
 from . import OneHotEncoder
 
@@ -167,6 +167,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             )
 
         valid_encode = ('onehot', 'onehot-dense', 'ordinal', 'min', 'max', 'mean', 'median', 'mode')
+
         if self.encode not in valid_encode:
             raise ValueError("Valid options for 'encode' are {}. "
                              "Got encode={!r} instead."
@@ -305,13 +306,16 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             Xt[:, jj] = np.digitize(Xt[:, jj] + eps, bin_edges[jj][1:])
         np.clip(Xt, 0, self.n_bins_ - 1, out=Xt)
 
-
         if self.encode == 'max':
             encoder = lambda x: np.max(x)
             return self._aggregate_encoder_helper(X, Xt, encoder)
 
         if self.encode == 'mode':
             encoder =  lambda x: stats.mode(x)[0][0]
+            return self._aggregate_encoder_helper(X, Xt, encoder)
+
+        if self.encode == 'mean':
+            encoder = lambda x: mean(x, axis=0)
             return self._aggregate_encoder_helper(X, Xt, encoder)
 
         if self.encode == 'ordinal':

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -18,7 +18,6 @@ X = [[-2, 1.5, -4, -1],
      [0, 3.5, -2, 0.5],
      [1, 4.5, -1, 2]]
 
-
 @pytest.mark.parametrize(
     'strategy, expected',
     [('uniform', [[0, 0, 0, 0], [1, 1, 1, 0], [2, 2, 2, 1], [2, 2, 2, 2]]),
@@ -239,6 +238,30 @@ def test_transform_mode():
     # check that original array is not mutated
     assert not np.array_equal(X , Xt)
 
+def test_transform_mean():
+
+    expected_2bins = [[-1.5, 2, -3.5, -0.75],
+                      [-1.5, 2, -3.5, -0.75],
+                      [ 0.5, 4, -1.5, 1.25],
+                      [ 0.5, 4, -1.5, 1.25]]
+
+    expected_3bins = [[-2, 1.5, -4, -1],
+                      [-1, 2.5, -3, -0.5],
+                      [0.5, 4, -1.5, 1.25],
+                      [0.5, 4, -1.5, 1.25]]
+
+    # for 2 bins
+    est = KBinsDiscretizer(n_bins=2, encode='mean')
+    Xt = est.fit_transform(X)
+    assert_array_equal(expected_2bins, Xt)
+
+    # for 3 bins
+    est = KBinsDiscretizer(n_bins=3, encode='mean')
+    Xt = est.fit_transform(X)
+    assert_array_equal(expected_3bins, Xt)
+
+    # ensure that original array is not mutated
+    assert not np.array_equal(X, Xt)
 
 @pytest.mark.parametrize(
     'strategy, expected_inv',


### PR DESCRIPTION
Reference Issues/PRs
issue reference: #7
parent PR: #1

What does this implement/fix? Explain your changes.
find the mean value for each bin after KBinsDiscretizer allocates each entry to a specific bin.