### PR TITLE
Add median encoder implementation to KBinsDiscretizer

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -10,7 +10,7 @@ import numbers
 import numpy as np
 import warnings
 import copy
-from scipy import stats, mean
+from scipy import stats, mean, median
 
 from . import OneHotEncoder
 
@@ -315,6 +315,9 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         if self.encode == 'mean':
             return self._aggregate_encoder_helper(X, Xt, lambda x: mean(x, axis=0))
+
+        if self.encode == 'median':
+            return self._aggregate_encoder_helper(X, Xt, lambda x: median(x, axis=0))
 
         if self.encode == 'ordinal':
             return Xt

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -262,6 +262,31 @@ def test_transform_mean():
     # ensure that original array is not mutated
     assert not np.array_equal(X, Xt)
 
+
+def test_transform_median():
+    expected_2bins = [[-1.5, 2, -3.5, -0.75],
+                      [-1.5, 2, -3.5, -0.75],
+                      [ 0.5, 4, -1.5, 1.25],
+                      [ 0.5, 4, -1.5, 1.25]]
+
+    expected_3bins = [[-2, 1.5, -4, -1],
+                      [-1, 2.5, -3, -0.5],
+                      [0.5, 4, -1.5, 1.25],
+                      [0.5, 4, -1.5, 1.25]]
+
+    # for 2 bins
+    est = KBinsDiscretizer(n_bins=2, encode='median')
+    Xt = est.fit_transform(X)
+    assert_array_equal(expected_2bins, Xt)
+
+    # for 3 bins
+    est = KBinsDiscretizer(n_bins=3, encode='median')
+    Xt = est.fit_transform(X)
+    assert_array_equal(expected_3bins, Xt)
+
+    # ensure that original array is not mutated
+    assert not np.array_equal(X, Xt)
+
 @pytest.mark.parametrize(
     'strategy, expected_inv',
     [('uniform', [[-1.5, 2., -3.5, -0.5], [-0.5, 3., -2.5, -0.5],


### PR DESCRIPTION
Reference Issues/PRs
issue reference: #8
parent PR: #1

What does this implement/fix? Explain your changes.
find the median value in each bin after KBinsDiscretizer allocates each entry to a specific bin.